### PR TITLE
Fix broken compile on ESP32.

### DIFF
--- a/SWire.cpp
+++ b/SWire.cpp
@@ -230,6 +230,7 @@ int SoftWire::write(uint8_t value) {
   }
   txBuffer[txBufferIndex] = value;
   txBufferIndex += 1;
+  return 1;
 }
 
 int SoftWire::write(int value) {


### PR DESCRIPTION
The ESP32 compiler is more strict about certain errors. It complains about
"control reaches end of non-void function [-Werror=return-type]" and stops
compiling. The error is legitimate since the function should return an int and
currently returns nothing, which turns into a random value.